### PR TITLE
Fix issue with 'Enable With Backorders' not working

### DIFF
--- a/classes/class-woo-product-stock-alert-frontend.php
+++ b/classes/class-woo-product-stock-alert-frontend.php
@@ -187,7 +187,7 @@ class WOO_Product_Stock_Alert_Frontend {
                 if ($product->backorders_allowed() && $visibility_backorder) {
                     $flag = true;
                 } else {
-                    if ($product->get_stock_quantity() < 1) {
+                    if (!$product->backorders_allowed() && $product->get_stock_quantity() < 1) {
                         $flag = true;
                     }
                 }


### PR DESCRIPTION
This is a quick fix for the issue with the subscribe box showing even when "Enable With Backorders" is disabled and the product is allowing backorder.

When the product's managing_stock() is enabled (returns true), there are two conditions in the code:
1. It will check if backorders are allowed and "enable with backorders" setting is true -> it shows the subscribe form which is OK
2. if that condition is not met it will go to another nested if, which checks if stock_quantity is <1. In cases where this is true but backorder is enabled it will set the flag = true which will show the subscribe box even if the "enable with backorders" setting is disabled.

Hopefully, I did not misunderstand the "enable with backorders"  setting and this fix is correct.

So the scenarios I've checked:

| Backorder enabled  | "Enable With Backorders" enabled  | Subscribe box showing|
| ------------- | ------------- | ------------- |
| YES  | YES  | YES |
| YES  | NO  | NO |
| NO  | NO  | NO |

The fix also works for variations and is showing the subscribe box when the product is out of stock.

Let me know if you need any further testing and/or comments.

Thanks.